### PR TITLE
minor typo in Kyla Quinn keynote abstract, fixing as courtesy

### DIFF
--- a/_pages/keynotes.md
+++ b/_pages/keynotes.md
@@ -62,7 +62,7 @@ Over the past three decades, Steven Bird has been working with minoritised peopl
 
 #### LLMs are great but ...
 #### Abstract
-Knowledge workers are crying out for ways to industrialised the boring parts of their jobs, company executives are looking for ways to get a computer to replace all the humans and everyone thinks an LLM will solve all of their problems. But how do we ensure that we aren't creating a catastrophic failure when we deploy LLMs in situations where we can’t afford to fail?
+Knowledge workers are crying out for ways to industrialise the boring parts of their jobs, company executives are looking for ways to get a computer to replace all the humans and everyone thinks an LLM will solve all of their problems. But how do we ensure that we aren't creating a catastrophic failure when we deploy LLMs in situations where we can’t afford to fail?
 
 In this keynote, I will explore some of the issues we need to contend with when we put LLMs and other language technologies into an enterprise. I will touch on data preprocessing, governance, user trust and interpretation. 
 


### PR DESCRIPTION
Minor typo, bypassing reviews and committing to `main`